### PR TITLE
Bugfix: tls_read(): use `.raw` instead of `.value`

### DIFF
--- a/tls/__init__.py
+++ b/tls/__init__.py
@@ -218,7 +218,7 @@ def tls_read(_ctx, _buflen=2048):
     r = lib.tls_read(_ctx, _buf, _buflen)
     if r == -1:
         raise TLSError(tls_error(_ctx))
-    return _buf.value
+    return _buf.raw[:r]
 
 
 def tls_write(_ctx, _data):


### PR DESCRIPTION
`.value` treats the underlying buffer as a NUL-terminated string, which will truncate binary data that contains '\0', whereas `.raw` returns the entire blob as-is